### PR TITLE
Feature/time headway

### DIFF
--- a/include/decision_maker.hpp
+++ b/include/decision_maker.hpp
@@ -46,6 +46,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/float64.hpp"
 #include "std_msgs/msg/string.hpp"
 
 namespace adore
@@ -108,6 +109,7 @@ private:
   rclcpp::Subscription<adore_ros2_msgs::msg::Waypoints>::SharedPtr           subscriber_waypoints;
   rclcpp::Subscription<adore_ros2_msgs::msg::TrafficSignals>::SharedPtr      subscriber_traffic_signals;
   rclcpp::Subscription<adore_ros2_msgs::msg::SafetyCorridor>::SharedPtr      subscriber_safety_corridor;
+  rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr                    subscriber_time_headway;
 
 
   using ParticipantsSubscriber = rclcpp::Subscription<adore_ros2_msgs::msg::TrafficParticipantSet>::SharedPtr;
@@ -140,6 +142,7 @@ private:
   void waypoints_callback( const adore_ros2_msgs::msg::Waypoints& waypoints );
   void suggested_trajectory_acceptance_callback( const std_msgs::msg::Bool& msg );
   void traffic_signals_callback( const adore_ros2_msgs::msg::TrafficSignals& msg );
+  void time_headway_callback( const std_msgs::msg::Float64& msg );
   void traffic_participants_callback( const adore_ros2_msgs::msg::TrafficParticipantSet& msg, const std::string& namespace_ );
 
 
@@ -148,6 +151,7 @@ private:
   bool                           only_follow_reference_trajectories     = false;
   double                         dt                                     = 0.05;
   double                         remote_operation_speed                 = 2.0;
+  double                         time_headway                           = 1.5;
   dynamics::VehicleCommandLimits command_limits                         = { 0.7, -2.0, 2.0 };
   std::map<std::string, double>  planner_settings;
 

--- a/src/decision_maker.cpp
+++ b/src/decision_maker.cpp
@@ -316,8 +316,12 @@ DecisionMaker::follow_route()
   }
   if( use_opti_nlc_route_following )
   {
+    double time_headway = 1.5; // time headway parameter
+    /*
+      // TIME HEADWAY CALCULATION //
+    */
     planned_trajectory = opti_nlc_trajectory_planner.plan_trajectory( cut_route, *latest_vehicle_state, *latest_local_map,
-                                                                      non_ego_traffic_participants );
+                                                                      non_ego_traffic_participants, time_headway );
   }
   else
   {
@@ -346,8 +350,9 @@ DecisionMaker::minimum_risk_maneuver()
   }
   if( use_opti_nlc_route_following )
   {
-    planned_trajectory = opti_nlc_trajectory_planner.plan_trajectory( cut_route, *latest_vehicle_state, *latest_local_map,
-                                                                      non_ego_traffic_participants );
+    double time_headway = 1.5;
+    planned_trajectory  = opti_nlc_trajectory_planner.plan_trajectory( cut_route, *latest_vehicle_state, *latest_local_map,
+                                                                       non_ego_traffic_participants, time_headway );
   }
   else
   {

--- a/src/decision_maker.cpp
+++ b/src/decision_maker.cpp
@@ -73,6 +73,10 @@ DecisionMaker::create_subscribers()
   subscriber_traffic_signals = create_subscription<adore_ros2_msgs::msg::TrafficSignals>(
     "traffic_signals", 1, std::bind( &DecisionMaker::traffic_signals_callback, this, std::placeholders::_1 ) );
 
+  subscriber_time_headway = create_subscription<std_msgs::msg::Float64>( "time_headway", 1,
+                                                                         std::bind( &DecisionMaker::time_headway_callback, this,
+                                                                                    std::placeholders::_1 ) );
+
   subscriber_suggested_trajectory_acceptance = create_subscription<std_msgs::msg::Bool>(
     "suggested_trajectory_accepted", 1,
     std::bind( &DecisionMaker::suggested_trajectory_acceptance_callback, this, std::placeholders::_1 ) );
@@ -316,7 +320,6 @@ DecisionMaker::follow_route()
   }
   if( use_opti_nlc_route_following )
   {
-    double time_headway = 1.5; // time headway parameter
     /*
       // TIME HEADWAY CALCULATION //
     */
@@ -414,6 +417,12 @@ DecisionMaker::route_callback( const adore_ros2_msgs::msg::Route& msg )
   latest_route = map::conversions::to_cpp_type( msg );
   if( latest_route->center_lane.size() < 2 )
     latest_route = std::nullopt;
+}
+
+void
+DecisionMaker::time_headway_callback( const std_msgs::msg::Float64& msg )
+{
+  time_headway = msg.data;
 }
 
 void


### PR DESCRIPTION
Implementation of a controllable time headway. 
In the previous implementation, the vehicle keeps a constant time headway with respect to the leading vehicle, in the car following scenario.
With this new feature, is possible to change the time headway dynamically.  The trajectory planner subscribes to the following topic:

subscriber_time_headway = create_subscription<std_msgs::msg::Float64>( "time_headway", 1,std::bind( &DecisionMaker::time_headway_callback, this, std::placeholders::_1 ) );

This topic contains the new desired time headway. Once this message is received, the planner will adapt consequently.
An example can be the merging scenario: the car is following the leading vehicle with a 2 seconds time headway, to allow the merging of another vehicle in between, a topic "time_headway" is published with value 4 seconds. The planner subscribes to this topic and adapts the new trajectory accordingly.
