### PR TITLE
Adaption to match new maploader feature WFS-downloader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(PROJECT_DEPS
   yaml-cpp
 )
 
+find_package(caches REQUIRED PATHS ${CMAKE_INSTALL_PREFIX}/../caches/lib/cmake/caches)
 foreach(pkg IN LISTS PROJECT_DEPS)
   find_package(${pkg} REQUIRED)
 endforeach()


### PR DESCRIPTION
Slight adaption of CMakeLists.txt to match new maploader feature WFS-downloader (I added just one line).

This PR is related to [PR 5](https://github.com/eclipse-adore/adore_map/pull/5) of adore_map, and to [PR 83](https://github.com/eclipse-adore/adore/pull/83) of adore.

It must be merged before [PR 83](https://github.com/eclipse-adore/adore/pull/83) of adore can be merged successfully.